### PR TITLE
[FIXED][DEV2.0.0][COLLAB] Fixed url on all html

### DIFF
--- a/ep/podcast.html
+++ b/ep/podcast.html
@@ -32,8 +32,8 @@
 
         <!-- Navegación -->
         <nav class="nav">
-          <a href="https://www.podcast.hoshimyanimation.com/index">Inicio</a>
-          <a href="https://www.podcast.hoshimyanimation.com/ep/podcast">Episodios</a>
+          <a href="https://podcast.hoshimyanimation.com/index">Inicio</a>
+          <a href="https://podcast.hoshimyanimation.com/ep/podcast">Episodios</a>
           <a href="https://www.hoshimyanimation.com/es/acerca">Nosotros</a>
         </nav>
       </div>

--- a/index-en.html
+++ b/index-en.html
@@ -31,8 +31,8 @@
 
         <!-- Navigation -->
         <nav class="nav">
-          <a href="https://www.podcast.hoshimyanimation.com/index">Home</a>
-          <a href="https://www.podcast.hoshimyanimation.com/ep/podcast">Episodes</a>
+          <a href="https://podcast.hoshimyanimation.com/index">Home</a>
+          <a href="https://podcast.hoshimyanimation.com/ep/podcast">Episodes</a>
           <a href="https://www.hoshimyanimation.com/en/about">About Us</a>
         </nav>
       </div>

--- a/index.html
+++ b/index.html
@@ -31,8 +31,9 @@
 
         <!-- Navegación -->
         <nav class="nav">
-          <a href="https://www.podcast.hoshimyanimation.com/index">Inicio</a>
-          <a href="https://www.podcast.hoshimyanimation.com/ep/podcast">Episodios</a>
+          
+          <a href="https://podcast.hoshimyanimation.com/index">Inicio</a>
+          <a href="https://podcast.hoshimyanimation.com/ep/podcast">Episodios</a>
           <a href="https://www.hoshimyanimation.com/es/acerca">Nosotros</a>
         </nav>
       </div>
@@ -121,8 +122,8 @@
     <p>&copy; 2026 Hoshimy Animation — Ideas que iluminan cielos.</p>
 
     <nav class="footer-nav">
-      <a href="es/acerca.html">Acerca</a>
-      <a href="es/privacidad.html">Privacidad</a>
+      <a href="https://www.hoshimyanimation.com/es/acerca">Acerca</a>
+      <a href="https://www.hoshimyanimation.com/es/privacidad">Privacidad</a>
       <a href="mailto:contacto@hoshimyanimation.com">Contacto</a>
     </nav>
 


### PR DESCRIPTION
This pull request updates navigation links across several HTML files to ensure consistent and correct usage of URLs, particularly removing the "www." subdomain from podcast-related links and ensuring all links point to the correct domains.

Navigation link updates:

* Updated navigation links in `index.html`, `index-en.html`, and `ep/podcast.html` to use `https://podcast.hoshimyanimation.com` instead of `https://www.podcast.hoshimyanimation.com` for podcast-related pages. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L34-R36) [[2]](diffhunk://#diff-be74d91bd8d5e1fd1c382962320d0f247f80c8c947b82f917a9fe3c7b0e05ab3L34-R35) [[3]](diffhunk://#diff-493bf9ec33435ec86ad7abc8655eec4a90112cb4dc9319f54bcb587ef14ac25fL35-R36)

Footer link updates:

* Changed footer links in `index.html` to use absolute URLs pointing to `https://www.hoshimyanimation.com` for the "Acerca" and "Privacidad" pages, instead of relative links.